### PR TITLE
Update adv360.keymap

### DIFF
--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -33,20 +33,20 @@
 
     default_layer {
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                           &mo 3 &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                            &none &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &none &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                            &kp HOME &kp PG_UP                           &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE              &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL    &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                                             &mo 3 &kp N6 &kp N7   &kp N8    &kp N9   &kp N0   &kp MINUS
+        &kp DEL      &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                              &none &kp Y  &kp U    &kp I     &kp O    &kp P    &kp BSLH
+        &kp ESC      &kp A     &kp S    &kp D    &kp F      &kp G  &none             &kp LGUI                 &kp LALT &kp LCTRL  &kp BSPC            &none &kp H  &kp J    &kp K     &kp L    &kp SEMI &kp SQT
+        &kp C_VOL_DN &kp Z     &kp X    &kp C    &kp V      &kp B                                             &kp HOME &kp PG_UP                            &kp N  &kp M    &kp COMMA &kp DOT  &kp FSLH &kp &C_VOL_UP
+        &mo 2        &kp GRAVE &kp NUBS &kp LEFT &kp RIGHT                &kp LSHIFT &mt TAB LS(LC(LA(LGUI))) &kp END  &kp PG_DN  &kp ENTER &kp SPACE              &kp DOWN &kp UP    &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &trans                                                           &mo 3 &kp N6 &kp KP_NUM &kp KP_EQUAL &kp KP_DIVIDE &kp KP_MULTIPLY &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                            &none &kp Y  &kp KP_N7  &kp KP_N8    &kp KP_N9     &kp KP_MINUS    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &none &kp H  &kp KP_N4  &kp KP_N5    &kp KP_N6     &kp KP_PLUS     &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                            &kp HOME &kp PG_UP                           &kp N  &kp KP_N1  &kp KP_N2    &kp KP_N3     &kp KP_ENTER    &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp KP_N0              &kp UP     &kp DOWN     &kp KP_DOT    &kp RBKT        &mo 2
+        &kp EQUAL    &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &trans                                                                            &mo 3  &kp N6 &kp KP_NUM &kp KP_EQUAL &kp KP_DIVIDE &kp KP_MULTIPLY &kp MINUS
+        &kp DEL      &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                             &none  &kp Y  &kp KP_N7  &kp KP_N8    &kp KP_N9     &kp KP_MINUS    &kp BSLH
+        &kp ESC      &kp A     &kp S    &kp D    &kp F      &kp G  &none             &kp LGUI                 &kp LALT &kp LCTRL  &kp BSPC           &none  &kp H  &kp KP_N4  &kp KP_N5    &kp KP_N6     &kp KP_PLUS     &kp SQT
+        &kp C_VOL_DN &kp Z     &kp X    &kp C    &kp V      &kp B                                             &kp HOME &kp PG_UP                            &kp N  &kp KP_N1  &kp KP_N2    &kp KP_N3     &kp KP_ENTER    &kp &C_VOL_UP
+        &mo 2        &kp GRAVE &kp NUBS &kp LEFT &kp RIGHT                &kp LSHIFT &mt TAB LS(LC(LA(LGUI))) &kp END   &kp PG_DN  &kp ENTER &kp KP_N0             &kp DOWN   &kp UP       &kp KP_DOT    &kp RBKT        &mo 2
       >;
     };
     fn {


### PR DESCRIPTION
Mac

## Advantage 360 Pro PR template

### What's changed:
* Moved shift to thumb cluster, use advantage 2 mac settings

### Why has this change been implemented:

### What (if any) actions must a user take after this change:

